### PR TITLE
Multiple auths

### DIFF
--- a/flask_fullstack/interfaces.py
+++ b/flask_fullstack/interfaces.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Union
+from typing import Type, TypeVar
+
+t = TypeVar("t", bound="Identifiable")
 
 
 class Identifiable:
@@ -17,19 +19,25 @@ class Identifiable:
         pass
 
     @classmethod
-    def find_by_id(cls, session, entry_id: int) -> Union[Identifiable, None]:
+    def find_by_id(cls: Type[t], session, entry_id: int) -> t | None:
         raise NotImplementedError
 
 
-class UserRole(Identifiable):
+class UserRole:
     """
     An interface to mark database classes as user roles, that can be used for authorization.
 
     Used in :ref:`.Namespace.jwt_authorizer`
     """
 
-    default_role: Union[UserRole, None] = None
+    unauthorized_error: tuple[int | str, str] = (403, "Permission denied")
+
+    def __init__(self, **kwargs):
+        pass
 
     @classmethod
-    def find_by_id(cls, session, entry_id: int) -> Union[UserRole, None]:
+    def find_by_identity(cls: Type[t], session, identity) -> t | None:
+        raise NotImplementedError
+
+    def get_identity(self) -> ...:
         raise NotImplementedError

--- a/flask_fullstack/interfaces.py
+++ b/flask_fullstack/interfaces.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Type, TypeVar
 
 t = TypeVar("t", bound="Identifiable")
+v = TypeVar("v")
 
 
 class Identifiable:
@@ -36,8 +37,8 @@ class UserRole:
         pass
 
     @classmethod
-    def find_by_identity(cls: Type[t], session, identity) -> t | None:
+    def find_by_identity(cls: Type[t], session, identity: v) -> t | None:
         raise NotImplementedError
 
-    def get_identity(self) -> ...:
+    def get_identity(self) -> v:
         raise NotImplementedError

--- a/flask_fullstack/mixins.py
+++ b/flask_fullstack/mixins.py
@@ -141,9 +141,7 @@ class JWTAuthorizerMixin(RawDatabaseSearcherMixin, metaclass=ABCMeta):
             @jwt_required(optional=optional)
             @self.with_begin
             def authorizer_inner(*args, **kwargs):
-                identity = self._get_identity().get(auth_name, None)
-
-                if identity is None:
+                if (t := self._get_identity()) is None or (identity := t.get(auth_name, None)) is None:
                     if optional:
                         kwargs[role.__name__.lower()] = None
                         return function(*args, **kwargs)

--- a/flask_fullstack/mixins.py
+++ b/flask_fullstack/mixins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABCMeta
 from functools import wraps
 from typing import Type, Union
@@ -29,6 +31,7 @@ class RawDatabaseSearcherMixin(AbstractAbortMixin, metaclass=ABCMeta):
     def with_begin(self, function):
         raise NotImplementedError
 
+    # deprecated
     def _database_searcher(self, identifiable: Type[Identifiable], check_only: bool, no_id: bool,
                            use_session: bool, error_code: int, callback, args, kwargs, *,
                            input_field_name: Union[str, None] = None, result_field_name: Union[str, None] = None):
@@ -47,26 +50,43 @@ class RawDatabaseSearcherMixin(AbstractAbortMixin, metaclass=ABCMeta):
 
 
 class DatabaseSearcherMixin(RawDatabaseSearcherMixin, metaclass=ABCMeta):
-    def database_searcher(self, identifiable: Type[Identifiable], *, result_field_name: Union[str, None] = None,
-                          check_only: bool = False, use_session: bool = False):
+    def database_searcher(self, identifiable: Type[Identifiable], *, input_field_name: str = None,
+                          result_field_name: str = None, check_only: bool = False, use_session: bool = False,
+                          error_code: int | str = " 404"):
         """
         - Uses incoming id argument to find something :class:`Identifiable` in the database.
         - If the entity wasn't found, will return a 404 response, which is documented automatically.
         - Can pass (entity's id or entity) and session objects to the decorated function.
 
         :param identifiable: identifiable to search for
-        :param result_field_name: overrides default name of found object [default is identifiable.__name__.lower()]
+        :param input_field_name: overrides default name of a parameter to search by
+        [default: identifiable.__name__.lower() + "_id"]
+        :param result_field_name: overrides default name of found object [default: identifiable.__name__.lower()]
         :param check_only: (default: False) if True, checks if entity exists and passes id to the decorated function
         :param use_session: (default: False) whether to pass the session to the decorated function
+        :param error_code: (default: " 404") an override for the documentation code for a not-found error
         """
+        if input_field_name is None:
+            input_field_name = identifiable.__name__.lower() + "_id"
+        if result_field_name is None:
+            result_field_name = identifiable.__name__.lower()
+
+        int_error_code: int = int(error_code)  # TODO redo doc_abort to handle this automagically
 
         def searcher_wrapper(function):
             @wraps(function)
-            @self.doc_abort("404 ", identifiable.not_found_text)
+            @self.doc_abort(error_code, identifiable.not_found_text, critical=True)
             @self.with_begin
             def searcher_inner(*args, **kwargs):
-                return self._database_searcher(identifiable, check_only, False, use_session, 404,
-                                               function, args, kwargs, result_field_name=result_field_name)
+                session = get_or_pop(kwargs, "session", use_session)
+                target_id: int = get_or_pop(kwargs, input_field_name, check_only)
+
+                if (result := identifiable.find_by_id(session, target_id)) is None:
+                    self.abort(int_error_code, identifiable.not_found_text)
+
+                if not check_only:
+                    kwargs[result_field_name] = result
+                return function(*args, **kwargs)
 
             return searcher_inner
 
@@ -79,7 +99,7 @@ class JWTAuthorizerMixin(RawDatabaseSearcherMixin, metaclass=ABCMeta):
         ("422 ", "InvalidJWT", True)
     ]
 
-    def jwt_authorizer(self, role: Type[UserRole], optional: bool = False,
+    def jwt_authorizer(self, role: Type[UserRole], *, result_field_name: str = None, optional: bool = False,
                        check_only: bool = False, use_session: bool = True):
         """
         - Authorizes user by JWT-token.
@@ -92,22 +112,31 @@ class JWTAuthorizerMixin(RawDatabaseSearcherMixin, metaclass=ABCMeta):
         :param optional: (default: False)
         :param check_only: (default: False) if True, user object won't be passed to the decorated function
         :param use_session: (default: True) whether to pass the session to the decorated function
+        :param result_field_name: overrides default name of found object [default: role.__name__.lower()]
         """
+        auth_errors = self.auth_errors.copy()
+        auth_errors.append(role.unauthorized_error + (True,))
+
+        if result_field_name is None:
+            result_field_name = role.__name__.lower()
 
         def authorizer_wrapper(function):
-            error_code: int = 401 if role is UserRole.default_role else 403
-
             @wraps(function)
-            @self.doc_aborts((f"{error_code} ", role.not_found_text, True), *self.auth_errors)
+            @self.doc_aborts(*auth_errors)
             @jwt_required(optional=optional)
             @self.with_begin
             def authorizer_inner(*args, **kwargs):
-                if (jwt := get_jwt_identity()) is None and optional:
+                if (target_id := get_jwt_identity()) is None and optional:
                     kwargs[role.__name__.lower()] = None
                     return function(*args, **kwargs)
-                kwargs["jwt"] = jwt
-                return self._database_searcher(role, check_only, True, use_session, error_code,
-                                               function, args, kwargs, input_field_name="jwt")
+
+                session = get_or_pop(kwargs, "session", use_session)
+                if (result := role.find_by_identity(session, target_id)) is None:
+                    self.abort(*role.unauthorized_error)
+
+                if not check_only:
+                    kwargs[result_field_name] = result
+                return function(*args, **kwargs)
 
             return authorizer_inner
 

--- a/flask_fullstack/restx.py
+++ b/flask_fullstack/restx.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from functools import wraps
 from typing import Union, Type, Sequence
 
-from flask import jsonify
+from flask import jsonify, Response
 from flask_jwt_extended import unset_jwt_cookies, set_access_cookies, create_access_token, jwt_required
 from flask_restx import Namespace, Model as BaseModel, abort as default_abort
 from flask_restx.fields import List as ListField, Boolean as BoolField, Integer as IntegerField, Nested
@@ -64,9 +64,9 @@ class RestXNamespace(Namespace, DatabaseSearcherMixin, JWTAuthorizerMixin):
             def adds_authorization_inner(*args, **kwargs):
                 response, result, headers = unpack(function(*args, **kwargs))
                 if isinstance(result, UserRole):
-                    response = jsonify(response)
+                    response = Response(response, 200, headers)
                     self.add_authorization(response, result, auth_name)
-                    return response, 200, headers
+                    return response
                 return response, result, headers
 
             return adds_authorization_inner

--- a/flask_fullstack/utils.py
+++ b/flask_fullstack/utils.py
@@ -4,6 +4,11 @@ from enum import Enum
 from typing import Union
 
 
+@property
+def NotImplementedField(_):
+    raise NotImplementedError
+
+
 class TypeEnum(Enum):
     @classmethod
     def from_string(cls, string: str) -> Union[TypeEnum, None]:


### PR DESCRIPTION
Due to me working on the [MUB project](https://github.com/moderator-hub) there was a need to add support for multiple auhtorization identities. So, for example, the same browser will be able to be signed in both as a moderator in MUB & a simple user in the main system, that the MUB is connected to, and all this while having just one cookie. 

This is achived by storing a dict in the jwt identity. FFS will provide methods to add & remove multiple auths to the cookies and the jwt_authorizer will be able to parse those. Single-auth configs will still work with very little overhead.

- [x] Update interfaces
- [x] Implement
- [x] Update typing
- [x] Testing for signle-auth variants
- [x] Testing for multiple-auth variants